### PR TITLE
Add Crc32c.getValueAsBytes

### DIFF
--- a/src/com/google/cloud/Crc32c.java
+++ b/src/com/google/cloud/Crc32c.java
@@ -115,11 +115,25 @@ public final class Crc32c implements Checksum {
 
   /**
    * Returns the value of the checksum.
-   * @return the value of the checksum.
+   * @return the long representation of the checksum (high bits set to zero).
    */
   @Override
   public long getValue() {
     return crc;
+  }
+
+  /**
+   * Returns the value of the checksum.
+   * @return the 4-byte array representation of the checksum in network byte order (big endian).
+   */
+  public byte[] getValueAsBytes() {
+    long value = crc;
+    byte[] result = new byte[4];
+    for (int i = 3; i >= 0; i--) {
+      result[i] = (byte) (value & 0xffL);
+      value >>= 8;
+    }
+    return result;
   }
 
   /**


### PR DESCRIPTION
Some callers want the byte array representation, e.g., for Google
Cloud Storage objects.  This method may help avoid confusion such as:

http://stackoverflow.com/questions/25096737/base64-encoding-of-crc32c-long-value
